### PR TITLE
Better alignment of labels and sliders

### DIFF
--- a/src/Preview.js
+++ b/src/Preview.js
@@ -73,7 +73,10 @@ export default class Preview extends Component {
         <div className="text-input">
           <input type="text" value={this.state.text} onInput={this.onTextChange} />
         </div>
-        <label>Size: </label><input type="range" min={0} max={100} value={this.state.fontSize} onInput={this.onFontSizeChange} />
+        <div className="font-size">
+          <label>Size:</label>
+          <input type="range" min={0} max={100} value={this.state.fontSize} onInput={this.onFontSizeChange} />
+        </div>
 
         <div className="feature-selector">
           <label>Script:</label>

--- a/src/index.html
+++ b/src/index.html
@@ -23,9 +23,16 @@
       margin-bottom: 10px;
     }
 
+    .preview .font-size label,
     .variation-selector .axis label {
       display: inline-block;
       width: 100px;
+    }
+
+    .preview .font-size input,
+    .variation-selector .axis input {
+      vertical-align: top;
+      vertical-align: -webkit-baseline-middle;
     }
 
     .preview > canvas {
@@ -62,7 +69,8 @@
       margin-top: 20px;
     }
 
-    .preview > label,
+    .variation-selector .axis > label,
+    .preview .font-size > label,
     .feature-selector > label {
       margin: 0 5px;
     }


### PR DESCRIPTION
Tested with Firefox, Chrome, and GtkWebKit on Linux, might look
different on other platforms.

Also made the size label and slider horizontally aligned to axis ones.

Should fix https://github.com/devongovett/fontkit-demo/issues/3

![image](https://user-images.githubusercontent.com/93914/27070592-5ca04c9c-5022-11e7-8de8-cfc912e428fc.png)
